### PR TITLE
fix: update Views heading typo

### DIFF
--- a/apps/previa/src/sections/Views.astro
+++ b/apps/previa/src/sections/Views.astro
@@ -17,7 +17,7 @@ import { RadiusGradientFrame } from '@components';
   <RadiusGradientFrame class="view-mode">
     <img src="/assets/img/laprevia-que-esperar.webp" alt="La Previa JSConf Chile 2024" />
     <div class="view-info">
-      <h3>¿Qué esperar de la precia?</h3>
+      <h3>¿Qué esperar de la previa?</h3>
       <p>
         En La Previa aprenderás de expertos/references en el área de JS. Tendremos diversos temas
         para personas sin y con experiencia. Pero hay más. Además, podrás ganar entradas para la


### PR DESCRIPTION
Replace typo "precia" with "previa" in the sentence "¿Qué esperar de la precia?"

### Por favor, comprueba si el PR cumple estos requisitos

- [x ] El mensaje del commit sigue nuestras directrices
- [ no aplica] Se han añadido pruebas para los cambios (para correcciones de errores / características)
- [ no aplica] Se han añadido / actualizado documentos (para correcciones de errores / características)


### ¿Qué tipo de cambio introduce este PR?
Content fix

### ¿Cuál es el comportamiento actual?
Aparece "precia" en vez de "previa", ver la issue #1 

### ¿Cuál es el nuevo comportamiento?
Aparece el heading correctamente

### ¿Este PR introduce un breaking change?
No
¿Qué cambios podrían tener que hacer los usuarios en su aplicación debido a este PR?
Ninguno

**Otra información**:
No aplica

